### PR TITLE
upgrade pyyaml to 6.0.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 pyroute2 == 0.7.2
 kopf[full-auth] == 1.35.6
 apischema == 0.17.5
-pyyaml == 6.0
+pyyaml == 6.0.1


### PR DESCRIPTION
docker build fails because of [pyyaml 6.0 and cpython 3.0](https://github.com/yaml/pyyaml/issues/601)

use pyyaml 6.0.1 to fix the build ...